### PR TITLE
아프리카 하위호환 추가 하면서 null 체크 안되있는 오류 수정

### DIFF
--- a/src/main/java/me/taromati/doneconnector/DoneConnector.java
+++ b/src/main/java/me/taromati/doneconnector/DoneConnector.java
@@ -134,8 +134,13 @@ public final class DoneConnector extends JavaPlugin implements Listener {
 
         try {
             Logger.debug(ChatColor.WHITE + "숲 아이디 로드 중...");
-            Set<String> nicknameList = this.getConfig().getConfigurationSection("숲").getKeys(false);
-            nicknameList.addAll(this.getConfig().getConfigurationSection("아프리카").getKeys(false));
+            Set<String> nicknameList = new HashSet<>();
+            if (this.getConfig().getConfigurationSection("숲") != null) {
+                nicknameList.addAll(this.getConfig().getConfigurationSection("숲").getKeys(false));
+            }
+            if (this.getConfig().getConfigurationSection("아프리카") != null) {
+                nicknameList.addAll(this.getConfig().getConfigurationSection("아프리카").getKeys(false));
+            }
             Logger.debug(nicknameList.toString());
 
             for (String nickname : nicknameList) {


### PR DESCRIPTION
혹시 SoopWebSocket에서 후원 쪽 읽어오는 설정이 COMMAND_CHAT으로 해두셨던데 특별한 이유가 있을까요??
이 부분에서 패킷 처리가 되서 그런지 후원 메시지 없이 보내는 후원은 인식이 안되더라구여